### PR TITLE
ci: add workflow to update language progress

### DIFF
--- a/.github/workflows/updateTranslationProgress.yml
+++ b/.github/workflows/updateTranslationProgress.yml
@@ -1,0 +1,28 @@
+name: SkyblockAddons Translation Progress Update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+
+jobs:
+  TranslationProgressUpdate:
+    name: Update SkyblockAddons Translation Progress
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - shell: bash
+      env:
+        CROWDIN_AUTH: ${{ secrets.CROWDIN_AUTH }}
+        GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+      run: |
+        curl -X GET https://crowdin.com/api/v2/projects/369493/languages/progress?limit=500 -H "Authorization: Bearer $CROWDIN_AUTH" -o translationProgress.json
+        git config user.name "Github Actions"
+        git config user.email "$GIT_EMAIL"
+        git fetch
+        git checkout data
+        git add --all
+        git commit -m "chore(SkyblockAddons): update translation progress"
+        git push
+      continue-on-error: true


### PR DESCRIPTION
This PR adds a workflow that runs every day at midnight UTC and fetches the Crowdin translation status and uploads it to a branch called "data" on a file called "translationProgress.json" located in the root of the branch. This workflow needs two env variables: CROWDIN_AUTH, a Crowdin API v2 token, and GIT_EMAIL, the email of the account that should commit these changes. The workflow can also be manually ran